### PR TITLE
Stored Pokemon Correction

### DIFF
--- a/sky-save-gui/src/tabs.rs
+++ b/sky-save-gui/src/tabs.rs
@@ -1,8 +1,8 @@
 use eframe::egui;
 use eframe::egui::{
     containers, vec2, Align, CentralPanel, CollapsingHeader, Color32, DragValue, Id, Layout,
-    Margin, Response, RichText, ScrollArea, Sense, Stroke, TextEdit, TextStyle, Ui, Vec2,
-    WidgetText,
+    Margin, Response, RichText, ScrollArea, Sense, Stroke, TextEdit, TextStyle, TopBottomPanel, Ui,
+    Vec2, WidgetText,
 };
 use egui_tiles::{Behavior, TabState, TileId, Tiles, UiResponse};
 use egui_virtual_list::VirtualList;
@@ -241,6 +241,17 @@ pub fn stored_ui(state: &mut StoredPokemonTab, ui: &mut Ui, save: &mut SkySave) 
                         });
                 });
             });
+
+            if let 2..5 = state.current {
+                TopBottomPanel::bottom("warning").show_separator_line(false).show_inside(ui, |ui| {
+                    ui.label(
+                        RichText::new(
+                            "Warning:\nThis slot is reserved for special episodes.\nEditing can cause unexpected behavior.",
+                        )
+                            .color(ui.style().visuals.warn_fg_color),
+                    );
+                });
+            };
         });
     });
 }

--- a/sky-save/src/offsets/stored.rs
+++ b/sky-save/src/offsets/stored.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 
 pub const STORED_PKM_BIT_LEN: usize = 362;
 pub const STORED_MOVE_BIT_LEN: usize = 21;
-pub const STORED_PKM_COUNT: usize = 720;
+pub const STORED_PKM_COUNT: usize = 550;
 pub const STORED_PKM_BITS: Range<usize> =
     0x464 * 8..(0x464 * 8 + STORED_PKM_BIT_LEN * STORED_PKM_COUNT);
 

--- a/sky-save/src/save.rs
+++ b/sky-save/src/save.rs
@@ -163,7 +163,7 @@ pub struct SkySave {
     pub quicksave_valid: bool,
 
     pub general: General,
-    pub stored_pokemon: ArrayVec<StoredPokemon, 720>,
+    pub stored_pokemon: ArrayVec<StoredPokemon, 550>,
     pub active_pokemon: ArrayVec<ActivePokemon, 4>,
 }
 
@@ -215,7 +215,7 @@ impl SkySave {
         let general = General::load(data, active_save_block);
         let bits = load_save_bits(data.view_bits(), active_save_block, stored::STORED_PKM_BITS);
 
-        let stored_pokemon: ArrayVec<StoredPokemon, 720> = bits
+        let stored_pokemon: ArrayVec<StoredPokemon, 550> = bits
             .chunks(stored::STORED_PKM_BIT_LEN)
             .map(StoredPokemon::from_bitslice)
             .collect();
@@ -282,11 +282,12 @@ impl SkySave {
                     acc
                 },
             );
+
         store_save_bits(
             self.data.view_bits_mut(),
             self.active_save_block,
             stored::STORED_PKM_BITS,
-            stored.as_bitslice(),
+            &stored.as_bitslice()[0..stored::STORED_PKM_BIT_LEN * stored::STORED_PKM_COUNT],
         );
 
         let active = self
@@ -302,6 +303,7 @@ impl SkySave {
                     acc
                 },
             );
+
         store_save_bits(
             self.data.view_bits_mut(),
             self.active_save_block,

--- a/sky-save/src/stored.rs
+++ b/sky-save/src/stored.rs
@@ -51,6 +51,11 @@ impl StoredMove {
 
 /// Represents a recruited Pokémon in Chimecho's Assembly.
 /// Holds information that isn't critical in dungeon mode.
+///
+/// There are 550 available slots.
+/// Slots 0-1 are reserved for the player and partner.
+/// Slots 2-4 are reserved for Pokemon from special episodes, they aren't available in the main story.
+/// Slots five onwards are available for recruited Pokemon.
 #[derive(Debug, Default, Clone)]
 pub struct StoredPokemon {
     pub valid: bool,


### PR DESCRIPTION
This PR makes changes to match the max number of recruits. There are 550 slots available, not 720. The first five slots are reserved for the leader and partner Pokemon, and for special episode Pokemon.
